### PR TITLE
W-11169954- update python runtime to 3.9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "aws_lambda_function" "ebs_bckup_lambda" {
   filename          = "${path.module}/lambda-${var.stack_prefix}-${var.unique_name}.zip"
   source_code_hash  = data.archive_file.lambda_zip.output_base64sha256
   role              = aws_iam_role.ebs_bckup-role-lambdarole.arn
-  runtime           = "python3.8"
+  runtime           = "python3.9"
   handler           = "ebs_bckup.lambda_handler"
   timeout           = var.timeout
   publish           = true


### PR DESCRIPTION
updated to 3.9 in test2, no failures when function was triggered. 